### PR TITLE
Fix embedded subtitle language labels and version bump to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with AllAnime and Anikoto providers"

--- a/src/download.rs
+++ b/src/download.rs
@@ -198,6 +198,8 @@ fn subtitle_mux_args(
         args.extend([
             format!("-metadata:s:s:{index}"),
             format!("title={}", subtitle.label),
+            format!("-metadata:s:s:{index}"),
+            format!("language={}", subtitle_language_code(&subtitle.label)),
             format!("-disposition:s:{index}"),
             if Some(index) == default_index || (default_index.is_none() && index == 0) {
                 "default".into()
@@ -208,6 +210,40 @@ fn subtitle_mux_args(
     }
     args.push(output.to_string_lossy().into_owned());
     args
+}
+
+fn subtitle_language_code(label: &str) -> &'static str {
+    let normalized = label.to_ascii_lowercase();
+    let label = normalized
+        .split(['(', '[', '-', '_'])
+        .next()
+        .unwrap_or(&normalized)
+        .trim();
+    match label {
+        "english" | "en" => "eng",
+        "polish" | "polski" | "pl" => "pol",
+        "spanish" | "español" | "espanol" | "es" => "spa",
+        "portuguese" | "português" | "portugues" | "pt" => "por",
+        "french" | "français" | "francais" | "fr" => "fra",
+        "german" | "deutsch" | "de" => "deu",
+        "italian" | "italiano" | "it" => "ita",
+        "japanese" | "日本語" | "ja" => "jpn",
+        "korean" | "한국어" | "ko" => "kor",
+        "chinese" | "中文" | "zh" => "zho",
+        "arabic" | "العربية" | "ar" => "ara",
+        "russian" | "русский" | "ru" => "rus",
+        "ukrainian" | "українська" | "uk" => "ukr",
+        "turkish" | "türkçe" | "turkce" | "tr" => "tur",
+        "indonesian" | "bahasa indonesia" | "id" => "ind",
+        "vietnamese" | "tiếng việt" | "tieng viet" | "vi" => "vie",
+        "thai" | "ไทย" | "th" => "tha",
+        "hindi" | "हिन्दी" | "hi" => "hin",
+        "dutch" | "nederlands" | "nl" => "nld",
+        "czech" | "čeština" | "cestina" | "cs" => "ces",
+        "romanian" | "română" | "romana" | "ro" => "ron",
+        "hungarian" | "magyar" | "hu" => "hun",
+        _ => "und",
+    }
 }
 
 async fn download_stream_inner(stream: &StreamLink, options: &DownloadOptions) -> Result<PathBuf> {
@@ -786,6 +822,8 @@ mod tests {
         );
         assert!(args.contains(&"-c:s".into()));
         assert!(args.contains(&"mov_text".into()));
+        assert!(args.contains(&"language=eng".into()));
+        assert!(args.contains(&"language=pol".into()));
     }
 
     #[test]
@@ -799,5 +837,12 @@ mod tests {
             "ass"
         );
         assert_eq!(subtitle_extension("http://127.0.0.1:1/r/token"), "vtt");
+    }
+
+    #[test]
+    fn subtitle_labels_map_to_mp4_language_codes() {
+        assert_eq!(subtitle_language_code("English (CC)"), "eng");
+        assert_eq!(subtitle_language_code("Português-BR"), "por");
+        assert_eq!(subtitle_language_code("Unknown Provider Label"), "und");
     }
 }


### PR DESCRIPTION
## Summary

Describe the problem and the resulting behavior. Keep unrelated changes in separate pull requests.

## Related issue

Closes #

## Testing

List the commands and platforms used to verify the change.

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

## Checklist

- [ ] The change is focused and its commit history is understandable.
- [ ] User-facing flags, environment variables, or behavior are documented.
- [ ] New scraper behavior has deterministic fixtures or mock-server coverage.
- [ ] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [ ] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [ ] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

