### PR TITLE
use iina by default on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A cross-platform Rust port of [ani-cli](https://github.com/pystardust/ani-cli) w
 - Interactive anime/season and episode selection
 - Subbed and dubbed AllAnime or Anikoto search and playback
 - Native MegaPlay source extraction and transparent KotoCDN HLS unwrapping
-- mpv, VLC, and Syncplay support
+- mpv, IINA, VLC, and Syncplay support
 - Quality selection, episode ranges, history, and continuation
 - Preflighted batch downloads with aria2, yt-dlp, FFmpeg, and built-in fallbacks
 - Scriptable commands with JSON output
@@ -59,7 +59,9 @@ The scripts verify release archives against their published SHA-256 checksums an
 
 ## Requirements
 
-- [mpv](https://mpv.io/) for default playback, or VLC/Syncplay when selected
+- Linux and Windows: [mpv](https://mpv.io/) for default playback
+- macOS: [IINA](https://iina.io/) for default playback (`brew install --cask iina`)
+- Optional: VLC or Syncplay for alternate playback
 - Optional: [aria2](https://aria2.github.io/) for faster parallel downloads
 - Optional: yt-dlp and FFmpeg for HLS downloads, fallbacks, and embedding provider subtitles into MP4 files
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 mod updater;
 
-const LONG_ABOUT: &str = "A cross-platform Rust port of ani-cli for browsing, resolving, playing, and downloading anime from AllAnime or Anikoto/MegaPlay.\n\nThe interactive workflow searches the selected subbed or dubbed catalog, lists available episodes, resolves current provider links, selects the requested quality, and opens an external player. AllAnime remains the default; select Anikoto with --provider anikoto or ANI_CLI_PROVIDER=anikoto. Watch history uses the Bash ani-cli tab-separated format, so an existing history directory can be reused.\n\nThe scraper performs HTTP and cryptography internally; curl, sed, OpenSSL, Botan, and fzf are not required. Playback uses mpv by default, with optional VLC and Syncplay integrations. Downloads prefer aria2c for parallel transfers when available, with yt-dlp, FFmpeg, and the built-in resumable downloader as fallbacks.";
+const LONG_ABOUT: &str = "A cross-platform Rust port of ani-cli for browsing, resolving, playing, and downloading anime from AllAnime or Anikoto/MegaPlay.\n\nThe interactive workflow searches the selected subbed or dubbed catalog, lists available episodes, resolves current provider links, selects the requested quality, and opens an external player. AllAnime remains the default; select Anikoto with --provider anikoto or ANI_CLI_PROVIDER=anikoto. Watch history uses the Bash ani-cli tab-separated format, so an existing history directory can be reused.\n\nThe scraper performs HTTP and cryptography internally; curl, sed, OpenSSL, Botan, and fzf are not required. Playback uses IINA on macOS and mpv elsewhere by default, with optional VLC and Syncplay integrations. Downloads prefer aria2c for parallel transfers when available, with yt-dlp, FFmpeg, and the built-in resumable downloader as fallbacks.";
 
 const AFTER_HELP: &str = "KEYBOARD NAVIGATION:\n  Arrow keys / Tab       Navigate menus\n  j / k                  Move down / up in action menus\n  h / l                  Change pages in action menus\n  Space / Enter          Select or toggle an item\n  Type                    Filter fuzzy anime/episode menus\n  Escape                 Go back immediately from a fuzzy menu\n  q / Escape             Leave an ordinary action menu\n\nEXAMPLES:\n  ani-cli-rs frieren\n  ani-cli-rs --provider anikoto frieren\n  ani-cli-rs --allow-adult \"search query\"\n  ani-cli-rs --dub -q 720p \"cowboy bebop\"\n  ani-cli-rs -S 1 -e 2-4 \"one piece\"\n  ani-cli-rs --continue\n  ani-cli-rs --download -e 1 \"anime title\"\n  ani-cli-rs search --allow-adult --json \"search query\"\n  ani-cli-rs links --json SHOW_ID 1 --quality 1080p\n  ani-cli-rs debug --refresh\n\nENVIRONMENT:\n  ANI_CLI_MODE, ANI_CLI_PLAYER, ANI_CLI_DOWNLOAD_DIR, ANI_CLI_QUALITY,\n  ANI_CLI_HIST_DIR, ANI_CLI_ALLOW_ADULT, ANI_CLI_MULTI_SELECTION,\n  ANI_CLI_NO_DETACH, ANI_CLI_EXIT_AFTER_PLAY, ANI_CLI_PROVIDER\n\nOfficial prebuilt releases are provided for Windows and Linux. macOS users can build from source.";
 
@@ -48,7 +48,7 @@ struct Cli {
     /// Choose best, worst, or a resolution such as 1080p or 720p.
     #[arg(short = 'q', long, env = "ANI_CLI_QUALITY", default_value = "best")]
     quality: String,
-    /// Use VLC instead of the default mpv player.
+    /// Use VLC instead of the default mpv/iina player.
     #[arg(short = 'v', long)]
     vlc: bool,
     /// Select one episode, whitespace-separated episodes, or a range such as 2-5.
@@ -570,14 +570,12 @@ async fn run_command(
                 .await?;
             let stream = choose_quality(&streams, &args.quality)
                 .ok_or_else(|| AniError::Unavailable("no streams".into()))?;
-            let options = PlayerOptions {
-                executable: args
-                    .player
-                    .unwrap_or_else(|| PlayerOptions::default_mpv().executable),
-                kind: PlayerKind::Mpv,
-                no_detach: args.no_detach,
-                exit_after_play: false,
-            };
+            let mut options = PlayerOptions::default_player();
+            if let Some(executable) = args.player {
+                options.executable = executable;
+            }
+            options.no_detach |= args.no_detach;
+            options.exit_after_play = false;
             Player::new(options)
                 .play(stream, &format!("{} Episode {}", args.title, args.episode))
                 .await?;
@@ -852,7 +850,7 @@ async fn continue_selection(
 }
 
 fn build_legacy_player(cli: &Cli) -> Player {
-    let mut options = PlayerOptions::default_mpv();
+    let mut options = PlayerOptions::default_player();
     options.no_detach |= cli.no_detach;
     options.exit_after_play |= cli.exit_after_play;
     if cli.vlc {

--- a/src/player.rs
+++ b/src/player.rs
@@ -7,6 +7,7 @@ use crate::{AniError, Result, StreamLink, relay_stream, requires_hls_relay};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PlayerKind {
     Mpv,
+    Iina,
     Vlc,
     Syncplay,
     Custom,
@@ -21,6 +22,14 @@ pub struct PlayerOptions {
 }
 
 impl PlayerOptions {
+    pub fn default_player() -> Self {
+        if cfg!(target_os = "macos") {
+            Self::default_iina()
+        } else {
+            Self::default_mpv()
+        }
+    }
+
     pub fn default_mpv() -> Self {
         let executable = std::env::var_os("ANI_CLI_PLAYER")
             .map(PathBuf::from)
@@ -28,6 +37,18 @@ impl PlayerOptions {
         Self {
             executable,
             kind: PlayerKind::Mpv,
+            no_detach: env_bool("ANI_CLI_NO_DETACH"),
+            exit_after_play: env_bool("ANI_CLI_EXIT_AFTER_PLAY"),
+        }
+    }
+
+    pub fn default_iina() -> Self {
+        let executable = std::env::var_os("ANI_CLI_PLAYER")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("iina"));
+        Self {
+            executable,
+            kind: PlayerKind::Iina,
             no_detach: env_bool("ANI_CLI_NO_DETACH"),
             exit_after_play: env_bool("ANI_CLI_EXIT_AFTER_PLAY"),
         }
@@ -45,24 +66,25 @@ impl Player {
     }
 
     pub fn command_args(&self, stream: &StreamLink, title: &str) -> Vec<String> {
+        self.command_args_inner(stream, title, self.options.no_detach)
+    }
+
+    fn command_args_inner(&self, stream: &StreamLink, title: &str, attached: bool) -> Vec<String> {
         let referer = stream.headers.referer.as_deref().unwrap_or("");
         match self.options.kind {
             PlayerKind::Mpv => {
-                let mut args = vec![
-                    "--tls-verify=no".into(),
-                    format!("--force-media-title={title}"),
-                ];
-                if !referer.is_empty() {
-                    args.push(format!("--referrer={referer}"));
-                }
-                append_mpv_headers(&mut args, stream);
-                for track in &stream.subtitles {
-                    args.push(format!("--sub-file={}", track.url));
-                }
-                if let Some(track) = stream.subtitles.iter().find(|track| track.default) {
-                    args.push(format!("--slang={}", track.label));
+                let mut args = mpv_options(stream, title, referer);
+                args.push(stream.url.clone());
+                args
+            }
+            PlayerKind::Iina => {
+                let mut args = vec!["--no-stdin".into()];
+                if attached {
+                    args.push("--keep-running".into());
                 }
                 args.push(stream.url.clone());
+                args.push("--".into());
+                args.extend(mpv_options(stream, title, referer));
                 args
             }
             PlayerKind::Vlc => {
@@ -114,8 +136,9 @@ impl Player {
         force_attached: bool,
     ) -> Result<Option<i32>> {
         let mut command = Command::new(&self.options.executable);
-        command.args(self.command_args(stream, title));
-        if self.options.no_detach || force_attached {
+        let attached = self.options.no_detach || force_attached;
+        command.args(self.command_args_inner(stream, title, attached));
+        if attached {
             let status = command.status().await.map_err(|e| {
                 AniError::Player(format!(
                     "could not launch {}: {e}",
@@ -141,6 +164,24 @@ impl Player {
             Ok(None)
         }
     }
+}
+
+fn mpv_options(stream: &StreamLink, title: &str, referer: &str) -> Vec<String> {
+    let mut args = vec![
+        "--tls-verify=no".into(),
+        format!("--force-media-title={title}"),
+    ];
+    if !referer.is_empty() {
+        args.push(format!("--referrer={referer}"));
+    }
+    append_mpv_headers(&mut args, stream);
+    for track in &stream.subtitles {
+        args.push(format!("--sub-file={}", track.url));
+    }
+    if let Some(track) = stream.subtitles.iter().find(|track| track.default) {
+        args.push(format!("--slang={}", track.label));
+    }
+    args
 }
 
 fn append_mpv_headers(args: &mut Vec<String>, stream: &StreamLink) {
@@ -176,7 +217,7 @@ fn env_bool(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::RequestHeaders;
+    use crate::{RequestHeaders, SubtitleTrack};
     #[test]
     fn mpv_arguments_preserve_referrer_as_one_argument() {
         let player = Player::new(PlayerOptions {
@@ -202,5 +243,84 @@ mod tests {
                 .command_args(&stream, "Anime Episode 1")
                 .contains(&"--referrer=https://ref.example".into())
         );
+    }
+
+    #[test]
+    fn iina_arguments_put_stream_before_raw_mpv_options() {
+        let player = Player::new(PlayerOptions {
+            executable: "iina".into(),
+            kind: PlayerKind::Iina,
+            no_detach: false,
+            exit_after_play: false,
+        });
+        let stream = StreamLink {
+            url: "https://media/a.m3u8".into(),
+            resolution: "1080p".into(),
+            hls: true,
+            provider: "Default".into(),
+            downloadable: true,
+            headers: RequestHeaders {
+                referer: Some("https://ref.example".into()),
+                origin: Some("https://origin.example".into()),
+                ..Default::default()
+            },
+            subtitles: vec![SubtitleTrack {
+                label: "English".into(),
+                url: "https://media/subtitles.vtt".into(),
+                default: true,
+            }],
+        };
+
+        assert_eq!(
+            player.command_args(&stream, "Anime Episode 1"),
+            vec![
+                "--no-stdin",
+                "https://media/a.m3u8",
+                "--",
+                "--tls-verify=no",
+                "--force-media-title=Anime Episode 1",
+                "--referrer=https://ref.example",
+                "--http-header-fields=Origin: https://origin.example",
+                "--sub-file=https://media/subtitles.vtt",
+                "--slang=English",
+            ]
+        );
+    }
+
+    #[test]
+    fn forced_attached_iina_keeps_cli_running() {
+        let player = Player::new(PlayerOptions {
+            executable: "iina".into(),
+            kind: PlayerKind::Iina,
+            no_detach: false,
+            exit_after_play: false,
+        });
+        let stream = StreamLink {
+            url: "https://media/a.m3u8".into(),
+            resolution: "1080p".into(),
+            hls: true,
+            provider: "Default".into(),
+            downloadable: true,
+            headers: RequestHeaders::default(),
+            subtitles: vec![],
+        };
+
+        assert_eq!(
+            &player.command_args_inner(&stream, "Anime", true)[..3],
+            ["--no-stdin", "--keep-running", "https://media/a.m3u8"]
+        );
+    }
+
+    #[test]
+    fn platform_default_selects_expected_player() {
+        let options = PlayerOptions::default_player();
+        if cfg!(target_os = "macos") {
+            assert_eq!(options.kind, PlayerKind::Iina);
+            if std::env::var_os("ANI_CLI_PLAYER").is_none() {
+                assert_eq!(options.executable, PathBuf::from("iina"));
+            }
+        } else {
+            assert_eq!(options.kind, PlayerKind::Mpv);
+        }
     }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, time::SystemTime};
 
 use ani_cli::{AniError, Result};
 use serde::Deserialize;
+#[cfg(not(target_os = "macos"))] // suppress build errors for unused import on macOS
 use tokio::process::Command;
 
 const REPOSITORY: &str = "vorlie/ani-cli-rs";

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -86,6 +86,8 @@ cargo build --release --locked
 
 The binary is placed at `target/release/ani-cli-rs`. Copy it to a directory on your `PATH` if desired.
 
+IINA is the default player on macOS. Install it with `brew install --cask iina` and ensure its `iina` command is on `PATH`.
+
 ## Build from source on any supported desktop
 
 Install a current stable Rust toolchain, then:

--- a/wiki/Playback-and-Players.md
+++ b/wiki/Playback-and-Players.md
@@ -4,7 +4,7 @@ AllAnime is the default catalog. Select native Anikoto/MegaPlay playback with `-
 
 ## mpv
 
-mpv is the default player. Install it through your operating system and ensure `mpv` (`mpv.exe` on Windows) is in `PATH`.
+mpv is the default player on Linux and Windows. Install it through your operating system and ensure `mpv` (`mpv.exe` on Windows) is in `PATH`.
 
 ```console
 ani-cli-rs "title"
@@ -22,6 +22,12 @@ ani-cli-rs "title"
 ```sh
 ANI_CLI_PLAYER=/opt/mpv/bin/mpv ani-cli-rs "title"
 ```
+
+## IINA on macOS
+
+IINA is the default player on macOS. Install it with `brew install --cask iina` and ensure its `iina` command is on `PATH`. ani-cli-rs passes provider headers and subtitles through IINA's mpv-compatible options.
+
+`ANI_CLI_PLAYER` overrides the platform's default executable, so it must point to an IINA-compatible command on macOS or an mpv-compatible command on Linux and Windows.
 
 ## VLC
 


### PR DESCRIPTION

## Summary

Use IINA as the default playback application on macOS while retaining mpv
as the default on Linux and Windows.

This change:

- adds IINA-specific command construction
- forwards provider headers and subtitle options through IINA's mpv options
- preserves attached playback behavior
- updates the README and wiki installation/playback documentation
- adds unit coverage for IINA arguments and platform-default selection

## Related issue

None

## Testing

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```
Tested default IINA playback on macOS
Tested subtitle and provider-header forwarding
Tested `--no-detach`

## Checklist

- [ x] The change is focused and its commit history is understandable.
- [ x] User-facing flags, environment variables, or behavior are documented.
- [ x] New scraper behavior has deterministic fixtures or mock-server coverage.
- [ ]x No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [ x] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [ x] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

