### PR TITLE
15 feature back to search after playing an episode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with Anikoto providers"

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,129 +246,148 @@ async fn run(cli: Cli) -> Result<()> {
             .transpose()?
             .unwrap_or_default()
     };
+    let player = build_legacy_player(&cli);
     let terminal = std::io::stdin().is_terminal();
-    let (show, episodes, selected, prepared_downloads) = if cli.continue_watching {
-        let Some((show, episodes, initial_episode)) =
-            continue_selection(&clients, &history, mode, cli.select_nth).await?
-        else {
-            return Ok(());
-        };
-        let selection = cli
-            .episode
-            .clone()
-            .or(initial_episode)
-            .ok_or_else(|| AniError::Unavailable("history entry has no next episode".into()))?;
-        let selected = expand_episode_selection(&selection, &episodes)?;
-        let prepared = if cli.download {
-            Some(require_download_preflight(
-                preflight_downloads(&clients, &show, &selected, mode, &cli.quality).await?,
-            )?)
-        } else {
-            None
-        };
-        (show, episodes, selected, prepared)
+    let mut use_continue = cli.continue_watching;
+    let mut initial_query = if cli.query.is_empty() {
+        None
     } else {
-        let mut initial_query = if cli.query.is_empty() {
-            None
-        } else {
-            Some(cli.query.join(" "))
-        };
-        'search: loop {
-            let query = if let Some(query) = initial_query.take() {
-                query
-            } else {
-                Input::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Search anime")
-                    .interact_text()
-                    .map_err(dialog_error)?
+        Some(cli.query.join(" "))
+    };
+    loop {
+        let (show, episodes, selected, prepared_downloads) = if use_continue {
+            let Some((show, episodes, initial_episode)) =
+                continue_selection(&clients, &history, mode, cli.select_nth).await?
+            else {
+                return Ok(());
             };
-            let results = clients
-                .search_with_options(
-                    cli.provider.unwrap_or_default(),
-                    &query,
-                    mode,
-                    SearchOptions {
-                        allow_adult: cli.allow_adult,
-                    },
-                )
-                .await?;
-            'anime: loop {
-                let purpose = if cli.download {
-                    SelectionPurpose::Download
+            let selection =
+                cli.episode.clone().or(initial_episode).ok_or_else(|| {
+                    AniError::Unavailable("history entry has no next episode".into())
+                })?;
+            let selected = expand_episode_selection(&selection, &episodes)?;
+            let prepared = if cli.download {
+                Some(require_download_preflight(
+                    preflight_downloads(&clients, &show, &selected, mode, &cli.quality).await?,
+                )?)
+            } else {
+                None
+            };
+            (show, episodes, selected, prepared)
+        } else {
+            'search: loop {
+                let query = if let Some(query) = initial_query.take() {
+                    query
                 } else {
-                    SelectionPurpose::Watch
+                    Input::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Search anime")
+                        .interact_text()
+                        .map_err(dialog_error)?
                 };
-                let Some(show) = select_search_result(&results, cli.select_nth, purpose)? else {
-                    continue 'search;
-                };
-                let episodes = clients.episodes(&show.id, show.provider, mode).await?;
-                'episode: loop {
-                    let selection = if let Some(selection) = cli.episode.clone() {
-                        selection
+                let results = clients
+                    .search_with_options(
+                        cli.provider.unwrap_or_default(),
+                        &query,
+                        mode,
+                        SearchOptions {
+                            allow_adult: cli.allow_adult,
+                        },
+                    )
+                    .await?;
+                'anime: loop {
+                    let purpose = if cli.download {
+                        SelectionPurpose::Download
                     } else {
-                        let Some(selection) =
-                            select_initial_episodes(&episodes, cli.multi_selection, purpose)?
-                        else {
-                            if results.len() == 1 {
-                                continue 'search;
-                            }
-                            continue 'anime;
+                        SelectionPurpose::Watch
+                    };
+                    let Some(show) = select_search_result(&results, cli.select_nth, purpose)?
+                    else {
+                        continue 'search;
+                    };
+                    let episodes = clients.episodes(&show.id, show.provider, mode).await?;
+                    'episode: loop {
+                        let selection = if let Some(selection) = cli.episode.clone() {
+                            selection
+                        } else {
+                            let Some(selection) =
+                                select_initial_episodes(&episodes, cli.multi_selection, purpose)?
+                            else {
+                                if results.len() == 1 {
+                                    continue 'search;
+                                }
+                                continue 'anime;
+                            };
+                            selection
                         };
-                        selection
-                    };
-                    let selected = expand_episode_selection(&selection, &episodes)?;
-                    let prepared = if cli.download {
-                        match preflight_downloads(&clients, &show, &selected, mode, &cli.quality)
+                        let selected = expand_episode_selection(&selection, &episodes)?;
+                        let prepared = if cli.download {
+                            match preflight_downloads(
+                                &clients,
+                                &show,
+                                &selected,
+                                mode,
+                                &cli.quality,
+                            )
                             .await?
-                        {
-                            DownloadPreflight::Ready(prepared) => Some(prepared),
-                            DownloadPreflight::Unavailable(failures)
-                                if can_retry_download_selection(
-                                    cli.episode.is_some(),
-                                    terminal,
-                                    cli.continue_watching,
-                                ) =>
                             {
-                                print_preflight_failures(&failures);
-                                continue 'episode;
+                                DownloadPreflight::Ready(prepared) => Some(prepared),
+                                DownloadPreflight::Unavailable(failures)
+                                    if can_retry_download_selection(
+                                        cli.episode.is_some(),
+                                        terminal,
+                                        use_continue,
+                                    ) =>
+                                {
+                                    print_preflight_failures(&failures);
+                                    continue 'episode;
+                                }
+                                DownloadPreflight::Unavailable(failures) => {
+                                    return Err(download_preflight_error(&failures));
+                                }
                             }
-                            DownloadPreflight::Unavailable(failures) => {
-                                return Err(download_preflight_error(&failures));
-                            }
-                        }
-                    } else {
-                        None
-                    };
-                    break 'search (show, episodes, selected, prepared);
+                        } else {
+                            None
+                        };
+                        break 'search (show, episodes, selected, prepared);
+                    }
                 }
             }
+        };
+        use_continue = false;
+        let download_directory = std::env::var_os("ANI_CLI_DOWNLOAD_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let context = PlaybackContext {
+            clients: &clients,
+            history: &history,
+            show: &show,
+            episodes: &episodes,
+            mode,
+            download_directory,
+            player: &player,
+        };
+        if let Some(prepared) = prepared_downloads {
+            for episode in &prepared {
+                execute_prepared_episode(&context, episode, true).await?;
+            }
+        } else {
+            for episode in &selected {
+                play_or_download(&context, episode, &cli.quality, false).await?;
+            }
         }
-    };
-    let player = build_legacy_player(&cli);
-    let download_directory = std::env::var_os("ANI_CLI_DOWNLOAD_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."));
-    let context = PlaybackContext {
-        clients: &clients,
-        history: &history,
-        show: &show,
-        episodes: &episodes,
-        mode,
-        download_directory,
-        player: &player,
-    };
-    if let Some(prepared) = prepared_downloads {
-        for episode in &prepared {
-            execute_prepared_episode(&context, episode, true).await?;
-        }
-    } else {
-        for episode in &selected {
-            play_or_download(&context, episode, &cli.quality, false).await?;
-        }
-    }
 
-    if should_offer_playback_controls(selected.len(), terminal, cli.download, cli.exit_after_play) {
-        interactive_after_play(&context, &selected[0], &cli.quality).await?;
+        if should_offer_playback_controls(
+            selected.len(),
+            terminal,
+            cli.download,
+            cli.exit_after_play,
+        ) && interactive_after_play(&context, &selected[0], &cli.quality).await?
+            == AfterPlayAction::Search
+        {
+            initial_query = None;
+            continue;
+        }
+        break;
     }
     Ok(())
 }
@@ -1130,7 +1149,7 @@ async fn interactive_after_play(
     context: &PlaybackContext<'_>,
     first: &str,
     initial_quality: &str,
-) -> Result<()> {
+) -> Result<AfterPlayAction> {
     let mut episode = first.to_owned();
     let mut quality = initial_quality.to_owned();
     loop {
@@ -1149,7 +1168,7 @@ async fn interactive_after_play(
             .interact_opt()
             .map_err(dialog_error)?
         else {
-            break;
+            break Ok(AfterPlayAction::Done);
         };
         match actions[choice] {
             PlaybackAction::Next => episode = adjacent_episode(context.episodes, &episode, 1)?,
@@ -1187,11 +1206,17 @@ async fn interactive_after_play(
                 };
                 quality = streams[index].resolution.clone();
             }
-            PlaybackAction::Quit => break,
+            PlaybackAction::BackToSearch => break Ok(AfterPlayAction::Search),
+            PlaybackAction::Quit => break Ok(AfterPlayAction::Done),
         }
         play_or_download(context, &episode, &quality, false).await?;
     }
-    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AfterPlayAction {
+    Done,
+    Search,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1201,6 +1226,7 @@ enum PlaybackAction {
     Previous,
     Select,
     ChangeQuality,
+    BackToSearch,
     Quit,
 }
 
@@ -1212,6 +1238,7 @@ impl PlaybackAction {
             Self::Previous => "Previous episode".into(),
             Self::Select => "Choose another episode".into(),
             Self::ChangeQuality => format!("Change quality (current: {quality})"),
+            Self::BackToSearch => "Back to anime search".into(),
             Self::Quit => "Quit ani-cli-rs".into(),
         }
     }
@@ -1230,6 +1257,7 @@ fn playback_actions(episodes: &[String], current: &str) -> Vec<PlaybackAction> {
     actions.extend([
         PlaybackAction::Select,
         PlaybackAction::ChangeQuality,
+        PlaybackAction::BackToSearch,
         PlaybackAction::Quit,
     ]);
     actions
@@ -1403,6 +1431,7 @@ mod tests {
                 PlaybackAction::Replay,
                 PlaybackAction::Select,
                 PlaybackAction::ChangeQuality,
+                PlaybackAction::BackToSearch,
                 PlaybackAction::Quit,
             ]
         );
@@ -1413,6 +1442,7 @@ mod tests {
                 PlaybackAction::Previous,
                 PlaybackAction::Select,
                 PlaybackAction::ChangeQuality,
+                PlaybackAction::BackToSearch,
                 PlaybackAction::Quit,
             ]
         );

--- a/wiki/Configuration-and-History.md
+++ b/wiki/Configuration-and-History.md
@@ -17,6 +17,7 @@ ani-cli-rs uses command-line options for one-off choices and environment variabl
 | `ANI_CLI_EXIT_AFTER_PLAY` | Propagate attached player failures |
 | `ANI_CLI_RS_INSTALL_DIR` | Installer/uninstaller target directory |
 | `ANI_CLI_RS_PROFILE` | Unix profile modified by install/uninstall scripts |
+| `ANI_CLI_PROVIDER` | Changes the default provider used by `ani-cli-rs`. Available providers: anikoto/anikoto2 |
 
 Boolean variables recognize `1`, `true`, or `yes` where consumed as application booleans.
 


### PR DESCRIPTION
## Summary

Implemented the post-play return-to-search flow

The controls menu now includes: `Back to anime search`
Selecting it exits the current playback control loop and returns to a fresh `Search anime` prompt without quitting `ani-cli-rs`. The initial query is consumed only once, so `ani-cli-rs frieren` will not keep reusing `frieren` after choosing back-to-search.

## Related issue

Closes #15 

## Testing

List the commands and platforms used to verify the change.

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

## Checklist

- [x] The change is focused and its commit history is understandable.
- [x] User-facing flags, environment variables, or behavior are documented.
- [ ] New scraper behavior has deterministic fixtures or mock-server coverage.
- [x] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [x] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [x] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

