### PR TITLE
fix(relay): stop wrapping subtitles as HLS on desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with Anikoto providers"

--- a/src/download.rs
+++ b/src/download.rs
@@ -9,7 +9,8 @@ use reqwest::header;
 use tokio::{fs::OpenOptions, io::AsyncWriteExt, process::Command};
 
 use crate::{
-    AniError, RequestHeaders, Result, StreamLink, SubtitleTrack, relay_stream, requires_hls_relay,
+    AniError, RequestHeaders, Result, StreamLink, SubtitleTrack,
+    relay_stream_without_hls_subtitles, requires_hls_relay,
 };
 
 const MAX_SUBTITLE_BYTES: usize = 16 * 1024 * 1024;
@@ -22,7 +23,10 @@ pub struct DownloadOptions {
 
 pub async fn download_stream(stream: &StreamLink, options: &DownloadOptions) -> Result<PathBuf> {
     if requires_hls_relay(stream) {
-        let (_relay, local) = relay_stream(stream).await?;
+        // Downloads never need subtitles exposed as synthetic HLS renditions:
+        // subtitle tracks are fetched separately (via the relayed sidecar
+        // URLs on `local.subtitles`) and muxed into the output with FFmpeg.
+        let (_relay, local) = relay_stream_without_hls_subtitles(stream).await?;
         let target = download_stream_inner(&local, options).await?;
         attach_subtitles(&local, &target).await?;
         return Ok(target);

--- a/src/hls_relay.rs
+++ b/src/hls_relay.rs
@@ -74,7 +74,36 @@ impl Drop for HlsRelay {
 }
 
 /// Starts a relay and returns a stream whose URL points at its loopback endpoint.
+///
+/// Subtitles are exposed both as plain sidecar URLs on the returned
+/// `StreamLink::subtitles` (used by desktop players via `--sub-file`) and as
+/// synthetic HLS subtitle renditions in the relayed master playlist. Android
+/// players only receive a single intent URL, so they rely on the HLS
+/// rendition to discover subtitles at all.
 pub async fn relay_stream(stream: &StreamLink) -> Result<(HlsRelay, StreamLink)> {
+    relay_stream_inner(stream, true).await
+}
+
+/// Like [`relay_stream`], but never exposes subtitles as synthetic HLS
+/// subtitle renditions in the master playlist.
+///
+/// Wrapping a single, potentially very long, subtitle file as one oversized
+/// HLS media segment does not match how HLS clients expect WebVTT segments
+/// to be chunked (RFC 8216 section 3.5), and it produces unreliable cue
+/// timing in some HLS demuxers (see issue #18). Desktop players do not need
+/// this: they are launched with an explicit `--sub-file` argument that
+/// points directly at the relayed sidecar subtitle, which this function
+/// still populates on the returned `StreamLink::subtitles`.
+pub async fn relay_stream_without_hls_subtitles(
+    stream: &StreamLink,
+) -> Result<(HlsRelay, StreamLink)> {
+    relay_stream_inner(stream, false).await
+}
+
+async fn relay_stream_inner(
+    stream: &StreamLink,
+    expose_subtitles_in_hls: bool,
+) -> Result<(HlsRelay, StreamLink)> {
     if !stream.hls {
         return Err(AniError::Input("only HLS streams can be relayed".into()));
     }
@@ -120,7 +149,6 @@ pub async fn relay_stream(stream: &StreamLink) -> Result<(HlsRelay, StreamLink)>
     let mut playlist_subtitles = Vec::with_capacity(local.subtitles.len());
     for track in &mut local.subtitles {
         let url = validate_upstream(&track.url)?;
-        let duration_seconds = probe_subtitle_duration(&state.client, &url, &stream.headers).await;
         let token = register(
             &state,
             url.clone(),
@@ -128,6 +156,11 @@ pub async fn relay_stream(stream: &StreamLink) -> Result<(HlsRelay, StreamLink)>
             ResourceKind::Subtitle,
         )?;
         track.url = local_url(address, &token);
+
+        if !expose_subtitles_in_hls {
+            continue;
+        }
+        let duration_seconds = probe_subtitle_duration(&state.client, &url, &stream.headers).await;
         let playlist_token = register(
             &state,
             url,
@@ -954,6 +987,73 @@ mod tests {
                 .unwrap(),
             "text/vtt"
         );
+    }
+
+    #[tokio::test]
+    async fn desktop_relay_omits_hls_subtitle_renditions_but_keeps_the_sidecar() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/media.m3u8"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/vnd.apple.mpegurl")
+                    .set_body_string("#EXTM3U\n#EXTINF:10,\nsegment.ts\n"),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/subtitles.vtt"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/vtt")
+                    .set_body_string("WEBVTT\n\n00:00:01.000 --> 00:00:04.500\nHello\n"),
+            )
+            .mount(&server)
+            .await;
+
+        let stream = StreamLink {
+            url: format!("{}/media.m3u8", server.uri()),
+            resolution: "Auto".into(),
+            hls: true,
+            provider: "MegaPlay".into(),
+            downloadable: true,
+            headers: RequestHeaders::default(),
+            subtitles: vec![SubtitleTrack {
+                label: "English".into(),
+                url: format!("{}/subtitles.vtt", server.uri()),
+                default: true,
+            }],
+        };
+        let (_relay, local) = relay_stream_without_hls_subtitles(&stream).await.unwrap();
+        let client = reqwest::Client::new();
+        let master = client
+            .get(&local.url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert!(!master.contains("#EXT-X-MEDIA:TYPE=SUBTITLES"));
+        assert!(!master.contains("SUBTITLES=\"aniplay-subs\""));
+
+        // The direct sidecar subtitle URL is still relayed and reachable, so
+        // desktop players can load it via `--sub-file`.
+        assert_eq!(local.subtitles.len(), 1);
+        let subtitle = client.get(&local.subtitles[0].url).send().await.unwrap();
+        assert_eq!(subtitle.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            subtitle
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "text/vtt"
+        );
+        let body = subtitle.text().await.unwrap();
+        assert!(body.contains("Hello"));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use anikoto_cz::{AnikotoCzClient, AnikotoCzClientBuilder};
 pub use download::{DownloadOptions, download_stream};
 pub use error::{AniError, Result};
 pub use history::{HistoryEntry, HistoryStore};
-pub use hls_relay::{HlsRelay, relay_stream};
+pub use hls_relay::{HlsRelay, relay_stream, relay_stream_without_hls_subtitles};
 pub use models::{
     CatalogProvider, RequestHeaders, SearchOptions, SearchResult, StreamLink, SubtitleTrack,
     TranslationType, choose_quality, expand_episode_selection,

--- a/src/player.rs
+++ b/src/player.rs
@@ -6,7 +6,10 @@ use std::{
 
 use tokio::process::Command;
 
-use crate::{AniError, Result, StreamLink, relay_stream, requires_hls_relay};
+use crate::{
+    AniError, Result, StreamLink, relay_stream, relay_stream_without_hls_subtitles,
+    requires_hls_relay,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PlayerKind {
@@ -148,7 +151,17 @@ impl Player {
 
     pub async fn play(&self, stream: &StreamLink, title: &str) -> Result<Option<i32>> {
         if requires_hls_relay(stream) || (self.is_android_player() && stream.hls) {
-            let (_relay, local) = relay_stream(stream).await?;
+            // Android players receive a single intent URL and cannot be given
+            // an explicit `--sub-file`, so they need subtitles exposed as
+            // synthetic HLS renditions. Desktop players already receive
+            // subtitles via `--sub-file`, and wrapping a long subtitle file as
+            // a single oversized HLS segment produces unreliable cue timing
+            // in some HLS demuxers (see issue #18).
+            let (_relay, local) = if self.is_android_player() {
+                relay_stream(stream).await?
+            } else {
+                relay_stream_without_hls_subtitles(stream).await?
+            };
             return self.play_inner(&local, title, true).await;
         }
         self.play_inner(stream, title, false).await


### PR DESCRIPTION
## Summary

Stop exposing external subtitles as synthetic HLS subtitle renditions to
desktop players and downloads.

- Add `relay_stream_without_hls_subtitles`, which relays subtitles as plain
  sidecar URLs only and never advertises them in the relayed master
  playlist's `EXT-X-MEDIA` tags.
- Use it for every non-Android player (mpv, IINA, VLC, Syncplay) and for
  downloads, both of which already receive subtitles directly via
  `--sub-file` or a separately downloaded/muxed sidecar file.
- Keep `relay_stream` (with the HLS subtitle rendition) for Android/Termux
  players, which receive a single intent URL and have no way to be handed an
  explicit subtitle file.

Wrapping an entire episode's WebVTT/SRT as one oversized single-segment HLS
media playlist does not match how HLS clients expect WebVTT to be chunked
(RFC 8216 section 3.5). It produced unreliable, rapidly changing subtitle
cue timing and `hls: The m3u8 list sequence may have been wrapped.` demuxer
noise in mpv/VLC on Linux, even when the desktop player also had the correct
sidecar subtitle loaded via `--sub-file` at the same time.

## Related issue

Fixes #18

## Testing

Windows 11 development checks:

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

All 76 deterministic tests pass, including a new test asserting that the
desktop relay path omits `EXT-X-MEDIA:TYPE=SUBTITLES` from the master
playlist while still relaying the sidecar subtitle URL correctly.

Manual verification against live `anikoto2` data (Dragon Quest: Adventure of
Dai, episode 93):

- Confirmed the relayed master playlist for desktop no longer contains a
  subtitle rendition, while `local.subtitles[].url` still resolves to the
  correct relayed sidecar `.vtt`/`.srt` file with the right `Content-Type`.
- Ran a full `ani-cli-rs download` for that episode, extracted the embedded
  `mov_text` subtitle track afterward, and confirmed it matches the source
  WebVTT's cue timing exactly (mux step does not corrupt timing).
- Confirmed the upstream WebVTT itself is well-formed for this episode: no
  backward timestamp jumps, no overlapping cues, no anomalously short cues.

Manual playback testing on Linux with mpv after the fix:

- Attack on Titan S3E1: no subtitle desync.
- Frieren: no subtitle desync.
- Dragon Quest: Adventure of Dai episode 93 (the title from #18): still
  shows some rapid/inconsistent timing. Given the raw subtitle and the
  mux pipeline both check out clean for this title, this looks isolated to
  that provider mirror/episode rather than the bug fixed here, and is being
  tracked separately.

## Checklist

- [x] The change is focused and its commit history is understandable.
- [x] User-facing flags, environment variables, or behavior are documented.
- [x] New scraper behavior has deterministic fixtures or mock-server coverage.
- [x] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [x] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [x] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.
