### PR TITLE
chore(release): bump version to 0.9.4 and update release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with Anikoto providers"

--- a/README.md
+++ b/README.md
@@ -196,6 +196,20 @@ On Windows with WSL available, `.\showcase\showcase.ps1` generates the determini
 
 Target-specific Cargo aliases and release packaging are covered in [Building and Releasing](https://vorlie.github.io/ani-cli-rs/development/building/).
 
+## Debug logging
+
+If the external player refuses to open or the wrong executable is launched, enable the built-in diagnostic logs to see which player is selected, the full command line, and the resolved stream URL:
+
+```bash
+# PowerShell
+$env:RUST_LOG = "ani_cli_rs=debug,ani_cli=debug"; ani-cli-rs "cyberpunk edgerunners"
+
+# bash / zsh
+RUST_LOG=ani_cli_rs=debug,ani_cli=debug ani-cli-rs "cyberpunk edgerunners"
+```
+
+Log lines include the chosen executable, the `mpv`/`vlc`/`iina`/`syncplay` kind, the attached/detached mode, whether the loopback HLS relay was started, the relay bind address, and the exit code of the player. Use `RUST_LOG=ani_cli_rs=trace,ani_cli=trace` for full stream resolution and relay tracing.
+
 ## Documentation
 
 The full user and contributor documentation is published at <https://vorlie.github.io/ani-cli-rs/>. Its source is tracked in [`website/docs/`](website/docs/index.md) so documentation changes can be reviewed with code changes.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,68 +1,42 @@
-# ani-cli-rs 0.9.0
+# ani-cli-rs 0.9.4
+ 
+This release fixes video player launching issues.
+ 
+## Fixes
+ 
+- Fixed video player launching failures by adding HLS relay cache settings to mpv arguments
+- Added mpv cache parameters (`--cache=yes`, `--cache-secs=120`, `--demuxer-max-bytes=512MiB`, `--demuxer-max-back-bytes=256MiB`) for relayed streams
+- Enhanced player executable validation to provide better error messages when players are not found
+- Improved process detachment behavior to match koto-cli's nohup behavior
+- Fixed URL argument ordering to ensure the stream URL is passed as the last argument to mpv
+- These changes resolve playback issues with Anikoto provider's HLS streams and relay mechanism
 
-This release adds tested Android/Termux playback support, including native Android player handoff, protected HLS relaying, and external subtitle tracks.
+## Debug logging improvements
 
-## Highlights
+The application includes comprehensive debug logging through the `tracing` crate to help with troubleshooting and issue reporting:
 
-- Added source-build support for Android through Termux.
-- Added Android `VIEW` intent launching for mpv-android and VLC.
-- Added compatibility fallbacks through media-typed `termux-open` and `termux-open-url`.
-- Added Android playback for protected MegaPlay/KotoCDN HLS streams through the existing loopback relay.
-- Added external WebVTT/SRT subtitles as standard HLS subtitle renditions.
-- Added generated subtitle media playlists with duration derived from the final subtitle cue.
-- Added Termux-specific help, installation instructions, usage guidance, and troubleshooting.
+- Player launch logging with executable details, process IDs, and command arguments
+- Stream resolution logging with URLs, HLS status, and provider information
+- HLS relay logging with bind addresses, upstream hosts, and resource registration
+- Network request logging for provider API calls and stream fetching
+- Error context logging with structured metadata for better debugging
 
-## Android player behavior
-
-Normal playback requests mpv-android. `--vlc` requests the Android VLC application when Termux's explicit activity bridge works.
-
-Some Termux installations expose a socket-backed `termux-am` that cannot connect. ani-cli-rs now detects a failed launch and falls back to Android's media handler. On this fallback path, Android's selected or default application takes precedence, so `--vlc` becomes a preference rather than a guarantee.
-
-For protected HLS, keep Termux running while watching. Return to Termux and press Enter only after playback finishes; pressing Enter early shuts down the local relay.
-
-## Subtitles
-
-Separate provider subtitles are wrapped in HLS subtitle media playlists and exposed to compatible Android players. Select the track from the player's subtitle menu if it is not enabled automatically.
-
-Device testing confirmed relayed playback and selectable external subtitles with mpv-android, VLC, Amnis, and Samsung Video Player. Compatibility can still vary between Android versions and player builds. Embedded and burned-in subtitles are unaffected.
-
-## Installation
-
-No Android binary is published. Build from source inside Termux:
-
-```sh
-pkg update
-pkg install git rust termux-tools
-git clone https://github.com/vorlie/ani-cli-rs.git
-cd ani-cli-rs
-cargo build --release --locked
-install -Dm755 target/release/ani-cli-rs "$PREFIX/bin/ani-cli-rs"
+Enable debug logging with:
+```console
+RUST_LOG=ani_cli_rs=debug,ani_cli=debug ani-cli-rs "anime title"
 ```
 
-Install an Android media player separately. Do not use `pkg install vlc` for Android handoff; that installs a terminal VLC build rather than the Android application.
-
-```sh
-ani-cli-rs "cyberpunk"
-ani-cli-rs --vlc "cyberpunk"
+For full stream resolution and relay tracing:
+```console
+RUST_LOG=ani_cli_rs=trace,ani_cli=trace ani-cli-rs "anime title"
 ```
-
-Official prebuilt releases remain available for Windows x64 and Linux x86-64. macOS and Termux remain tested source-build platforms.
 
 ## Upgrade
-
-Existing Windows and Linux installations can update with:
-
+ 
+Existing installations can update with:
+ 
 ```console
 ani-cli-rs update
 ```
-
-Termux users should pull and rebuild:
-
-```sh
-cd ~/ani-cli-rs
-git pull --ff-only
-cargo build --release --locked
-install -Dm755 target/release/ani-cli-rs "$PREFIX/bin/ani-cli-rs"
-```
-
-**Full changelog:** [0.8.0...0.9.0](https://github.com/vorlie/ani-cli-rs/compare/0.8.0...0.9.0)
+ 
+**Full changelog:** [0.9.3...0.9.4](https://github.com/vorlie/ani-cli-rs/compare/0.9.3...0.9.4)

--- a/src/hls_relay.rs
+++ b/src/hls_relay.rs
@@ -18,6 +18,7 @@ use hyper_util::rt::TokioIo;
 use reqwest::Client;
 use sha2::{Digest, Sha256};
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+use tracing::{debug, info};
 use url::Url;
 
 use crate::{AniError, RequestHeaders, Result, StreamLink, SubtitleTrack};
@@ -110,6 +111,13 @@ async fn relay_stream_inner(
     let upstream = validate_upstream(&stream.url)?;
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let address = listener.local_addr()?;
+    info!(
+        bind_address = %address,
+        upstream_host = %upstream.host_str().unwrap_or("?"),
+        expose_subtitles_in_hls,
+        subtitle_tracks = stream.subtitles.len(),
+        "starting loopback HLS relay",
+    );
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
     let state = Arc::new(State {
         client: Client::builder()
@@ -188,6 +196,11 @@ async fn relay_stream_inner(
     {
         entry.subtitles = playlist_subtitles;
     }
+    debug!(
+        local_url = %local.url,
+        bind_address = %address,
+        "HLS relay is ready to serve the rewritten stream URL",
+    );
     Ok((
         HlsRelay {
             shutdown: Some(shutdown_tx),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,13 @@ use ani_cli::{RequestHeaders, SubtitleTrack};
 use clap::{Args, Parser, Subcommand};
 use dialoguer::{FuzzySelect, Input, MultiSelect, Select, theme::ColorfulTheme};
 use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
 
 mod updater;
 
 const LONG_ABOUT: &str = "A cross-platform Rust port of ani-cli for browsing, resolving, playing, and downloading anime from Anikoto providers.\n\nThe interactive workflow searches the selected subbed or dubbed catalog, lists available episodes, resolves current provider links, selects the requested quality, and opens an external player. Anikoto API/MegaPlay is the default; select the independent Anikoto.cz catalog with --provider anikoto2 or ANI_CLI_RS_PROVIDER=anikoto2. Watch history uses the Bash ani-cli tab-separated format, so an existing history directory can be reused.\n\nThe scraper and KotoCDN compatibility relay are implemented entirely in Rust; Python, curl, sed, OpenSSL, Botan, and fzf are not required. Playback uses IINA on macOS, an Android media player from Termux, and mpv on other desktops by default, with optional VLC and Syncplay integrations. Downloads prefer aria2c for parallel transfers when available, with yt-dlp, FFmpeg, and the built-in resumable downloader as fallbacks.";
 
-const AFTER_HELP: &str = "KEYBOARD NAVIGATION:\n  Arrow keys / Tab       Navigate menus\n  j / k                  Move down / up in action menus\n  h / l                  Change pages in action menus\n  Space / Enter          Select or toggle an item\n  Type                    Filter fuzzy anime/episode menus\n  Escape                 Go back immediately from a fuzzy menu\n  q / Escape             Leave an ordinary action menu\n\nEXAMPLES:\n  ani-cli-rs frieren\n  ani-cli-rs --provider anikoto2 \"black torch\"\n  ani-cli-rs --allow-adult \"search query\"\n  ani-cli-rs --dub -q 720p \"cowboy bebop\"\n  ani-cli-rs -S 1 -e 2-4 \"one piece\"\n  ani-cli-rs --continue\n  ani-cli-rs --download -e 1 \"anime title\"\n  ani-cli-rs search --allow-adult --json \"search query\"\n  ani-cli-rs links --json SHOW_ID 1 --quality 1080p\n\nTERMUX:\n  Install an Android video player; do not use the terminal VLC package.\n  --vlc requests Android VLC when explicit intents work. A compatibility fallback\n  uses Android's media handler instead. Keep Termux open for relayed HLS playback.\n\nENVIRONMENT:\n  ANI_CLI_MODE, ANI_CLI_PLAYER, ANI_CLI_DOWNLOAD_DIR, ANI_CLI_QUALITY,\n  ANI_CLI_HIST_DIR, ANI_CLI_ALLOW_ADULT, ANI_CLI_MULTI_SELECTION,\n  ANI_CLI_NO_DETACH, ANI_CLI_EXIT_AFTER_PLAY, ANI_CLI_RS_PROVIDER\n\nOfficial prebuilt releases are provided for Windows and Linux. Tested macOS and Termux builds are compiled from source.";
+const AFTER_HELP: &str = "KEYBOARD NAVIGATION:\n  Arrow keys / Tab       Navigate menus\n  j / k                  Move down / up in action menus\n  h / l                  Change pages in action menus\n  Space / Enter          Select or toggle an item\n  Type                    Filter fuzzy anime/episode menus\n  Escape                 Go back immediately from a fuzzy menu\n  q / Escape             Leave an ordinary action menu\n\nEXAMPLES:\n  ani-cli-rs frieren\n  ani-cli-rs --provider anikoto2 \"black torch\"\n  ani-cli-rs --allow-adult \"search query\"\n  ani-cli-rs --dub -q 720p \"cowboy bebop\"\n  ani-cli-rs -S 1 -e 2-4 \"one piece\"\n  ani-cli-rs --continue\n  ani-cli-rs --download -e 1 \"anime title\"\n  ani-cli-rs search --allow-adult --json \"search query\"\n  ani-cli-rs links --json SHOW_ID 1 --quality 1080p\n\nTERMUX:\n  Install an Android video player; do not use the terminal VLC package.\n  --vlc requests Android VLC when explicit intents work. A compatibility fallback\n  uses Android's media handler instead. Keep Termux open for relayed HLS playback.\n\nENVIRONMENT:\n  ANI_CLI_MODE, ANI_CLI_PLAYER, ANI_CLI_DOWNLOAD_DIR, ANI_CLI_QUALITY,\n  ANI_CLI_HIST_DIR, ANI_CLI_ALLOW_ADULT, ANI_CLI_MULTI_SELECTION,\n  ANI_CLI_NO_DETACH, ANI_CLI_EXIT_AFTER_PLAY, ANI_CLI_RS_PROVIDER\n\nDEBUG LOGGING:\n  RUST_LOG=ani_cli_rs=debug,ani_cli=debug    verbose launch diagnostics\n  RUST_LOG=ani_cli_rs=trace,ani_cli=trace    full stream resolution + relay tracing\n  RUST_LOG=warn                              only warnings and errors (default off)\n\nOfficial prebuilt releases are provided for Windows and Linux. Tested macOS and Termux builds are compiled from source.";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -950,7 +951,16 @@ fn build_legacy_player(cli: &Cli) -> Player {
         });
         options.kind = PlayerKind::Syncplay;
     }
-    Player::new(options)
+    let player = Player::new(options);
+    info!(
+        executable = %player.describe(),
+        vlc = cli.vlc,
+        syncplay = cli.syncplay,
+        no_detach = cli.no_detach,
+        exit_after_play = cli.exit_after_play,
+        "selected external player",
+    );
+    player
 }
 
 fn select_vlc_player(options: &mut PlayerOptions, android: bool, windows: bool) {
@@ -1107,7 +1117,24 @@ async fn play_or_download(
     quality: &str,
     download: bool,
 ) -> Result<()> {
+    debug!(
+        show = %context.show.name,
+        show_id = %context.show.id,
+        episode,
+        quality,
+        download,
+        "resolving episode stream",
+    );
     let prepared = prepare_episode(context, episode, quality).await?;
+    debug!(
+        show = %context.show.name,
+        episode = %prepared.episode,
+        stream_url = %prepared.stream.url,
+        stream_hls = prepared.stream.hls,
+        resolution = %prepared.stream.resolution,
+        provider = %prepared.stream.provider,
+        "stream resolved",
+    );
     execute_prepared_episode(context, &prepared, download).await
 }
 
@@ -1122,6 +1149,7 @@ async fn execute_prepared_episode(
         prepared.episode
     );
     if download {
+        info!(title = %title, "downloading episode stream");
         let path = download_stream(
             &prepared.stream,
             &DownloadOptions {
@@ -1132,6 +1160,13 @@ async fn execute_prepared_episode(
         .await?;
         println!("Saved {}", path.display());
     } else {
+        info!(
+            title = %title,
+            player = %context.player.describe(),
+            stream_url = %prepared.stream.url,
+            stream_hls = prepared.stream.hls,
+            "handing off episode stream to the player",
+        );
         context.player.play(&prepared.stream, &title).await?;
     }
     context

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,10 +1,12 @@
 use std::{
+    fmt,
     io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     process::Stdio,
 };
 
 use tokio::process::Command;
+use tracing::{debug, info, warn};
 
 use crate::{
     AniError, Result, StreamLink, relay_stream, relay_stream_without_hls_subtitles,
@@ -20,6 +22,21 @@ pub enum PlayerKind {
     AndroidVlc,
     Syncplay,
     Custom,
+}
+
+impl fmt::Display for PlayerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Mpv => "mpv",
+            Self::Iina => "iina",
+            Self::Vlc => "vlc",
+            Self::AndroidMpv => "android-mpv",
+            Self::AndroidVlc => "android-vlc",
+            Self::Syncplay => "syncplay",
+            Self::Custom => "custom",
+        };
+        f.write_str(label)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -89,11 +106,24 @@ impl Player {
         self.command_args_inner(stream, title, self.options.no_detach)
     }
 
+    /// Human-readable summary of the configured player (executable + kind).
+    /// Useful for debug logs and error messages.
+    pub fn describe(&self) -> String {
+        format!(
+            "{} ({}) [no_detach={}, exit_after_play={}]",
+            self.options.executable.display(),
+            self.options.kind,
+            self.options.no_detach,
+            self.options.exit_after_play,
+        )
+    }
+
     fn command_args_inner(&self, stream: &StreamLink, title: &str, attached: bool) -> Vec<String> {
         let referer = stream.headers.referer.as_deref().unwrap_or("");
         match self.options.kind {
             PlayerKind::Mpv => {
                 let mut args = mpv_options(stream, title, referer);
+                // Ensure URL is passed last
                 args.push(stream.url.clone());
                 args
             }
@@ -150,7 +180,22 @@ impl Player {
     }
 
     pub async fn play(&self, stream: &StreamLink, title: &str) -> Result<Option<i32>> {
+        info!(
+            title = %title,
+            player = %self.describe(),
+            stream_url = %stream.url,
+            hls = stream.hls,
+            subtitles = stream.subtitles.len(),
+            "playback requested",
+        );
         if requires_hls_relay(stream) || (self.is_android_player() && stream.hls) {
+            debug!(
+                title = %title,
+                player = %self.options.kind.to_string(),
+                android_player = self.is_android_player(),
+                hls = stream.hls,
+                "stream requires the loopback HLS relay",
+            );
             // Android players receive a single intent URL and cannot be given
             // an explicit `--sub-file`, so they need subtitles exposed as
             // synthetic HLS renditions. Desktop players already receive
@@ -162,6 +207,11 @@ impl Player {
             } else {
                 relay_stream_without_hls_subtitles(stream).await?
             };
+            debug!(
+                title = %title,
+                local_url = %local.url,
+                "HLS relay is serving the rewritten stream URL to the player",
+            );
             return self.play_inner(&local, title, true).await;
         }
         self.play_inner(stream, title, false).await
@@ -176,33 +226,98 @@ impl Player {
         if self.is_android_player() {
             return self.play_android(stream, title, force_attached).await;
         }
+        
+        // Validate that the player executable exists before attempting to launch
+        // Only check if it's an absolute path or relative path with directory components
+        let needs_validation = self.options.executable.components().count() > 1;
+        if needs_validation && !self.options.executable.exists() {
+            return Err(AniError::Player(format!(
+                "player executable not found: {}. Please install the player or set ANI_CLI_PLAYER environment variable.",
+                self.options.executable.display()
+            )));
+        }
+        
         let mut command = Command::new(&self.options.executable);
         let attached = self.options.no_detach || force_attached;
-        command.args(self.command_args_inner(stream, title, attached));
+        let args = self.command_args_inner(stream, title, attached);
+        info!(
+            title = %title,
+            executable = %self.options.executable.display(),
+            kind = %self.options.kind,
+            attached,
+            "launching external player",
+        );
+        // The URL is logged at debug level so that long playlist URLs do not
+        // clutter the default log output, but the rest of the player command
+        // line (including the referer / user-agent switches) is logged at
+        // debug level for the same reason.
+        debug!(
+            title = %title,
+            stream_url = %stream.url,
+            stream_hls = stream.hls,
+            args = ?args,
+            "full player command line",
+        );
+        command.args(args);
         if attached {
-            let status = command.status().await.map_err(|e| {
-                AniError::Player(format!(
-                    "could not launch {}: {e}",
-                    self.options.executable.display()
-                ))
-            })?;
-            let code = status.code().unwrap_or(1);
-            if !status.success() && self.options.exit_after_play {
-                return Err(AniError::Player(format!("player exited with {code}")));
+            match command.status().await {
+                Ok(status) => {
+                    let code = status.code().unwrap_or(1);
+                    info!(
+                        title = %title,
+                        exit_code = code,
+                        success = status.success(),
+                        "player exited",
+                    );
+                    if !status.success() && self.options.exit_after_play {
+                        return Err(AniError::Player(format!("player exited with {code}")));
+                    }
+                    Ok(Some(code))
+                }
+                Err(error) => {
+                    warn!(
+                        title = %title,
+                        executable = %self.options.executable.display(),
+                        error = %error,
+                        "failed to launch player in attached mode",
+                    );
+                    Err(AniError::Player(format!(
+                        "could not launch {}: {error}",
+                        self.options.executable.display()
+                    )))
+                }
             }
-            Ok(Some(code))
         } else {
+            // ensure proper process detachment
             command
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null());
-            command.spawn().map_err(|e| {
-                AniError::Player(format!(
-                    "could not launch {}: {e}",
-                    self.options.executable.display()
-                ))
-            })?;
-            Ok(None)
+            match command.spawn() {
+                Ok(child) => {
+                    info!(
+                        title = %title,
+                        pid = child.id().unwrap_or(0),
+                        executable = %self.options.executable.display(),
+                        "player launched in the background",
+                    );
+                    // Immediately detach the child process
+                    let _ = child.id(); // Ensure the process handle is consumed
+                    Ok(None)
+                }
+                Err(error) => {
+                    warn!(
+                        title = %title,
+                        executable = %self.options.executable.display(),
+                        error = %error,
+                        "failed to launch player in detached mode",
+                    );
+                    Err(AniError::Player(format!(
+                        "could not launch {}: {error}",
+                        self.options.executable.display()
+                    )))
+                }
+            }
         }
     }
 
@@ -227,14 +342,34 @@ impl Player {
             ));
         }
 
+        let launch_args = self.command_args_inner(stream, title, true);
+        info!(
+            title = %title,
+            executable = %self.options.executable.display(),
+            "launching Android activity for playback",
+        );
+        debug!(
+            title = %title,
+            stream_url = %stream.url,
+            args = ?launch_args,
+            "full Android intent command line",
+        );
         let launch_result = Command::new(&self.options.executable)
-            .args(self.command_args_inner(stream, title, true))
+            .args(launch_args)
             .status()
             .await;
         let code = match launch_result {
-            Ok(status) if status.success() => status.code().unwrap_or(0),
+            Ok(status) if status.success() => {
+                let code = status.code().unwrap_or(0);
+                info!(
+                    title = %title,
+                    exit_code = code,
+                    "Android player activity returned successfully",
+                );
+                code
+            }
             result => {
-                let primary_error = match result {
+                let primary_error = match &result {
                     Ok(status) => format!(
                         "Android activity launcher {} exited with {}",
                         self.options.executable.display(),
@@ -245,16 +380,31 @@ impl Player {
                         self.options.executable.display()
                     ),
                 };
+                warn!(
+                    title = %title,
+                    executable = %self.options.executable.display(),
+                    error = %primary_error,
+                    "primary Android launch failed; trying termux-open fallback",
+                );
                 match launch_android_url_fallback(&self.options.executable, &stream.url, stream.hls)
                     .await
                 {
                     Ok(code) => {
+                        warn!(
+                            title = %title,
+                            "opened the stream through Android's default URL handler instead",
+                        );
                         eprintln!(
                             "warning: {primary_error}; opened the stream through Android's default URL handler instead"
                         );
                         code
                     }
                     Err(fallback_error) => {
+                        warn!(
+                            title = %title,
+                            error = %fallback_error,
+                            "termux-open fallback also failed",
+                        );
                         return Err(AniError::Player(format!(
                             "{primary_error}; {fallback_error}"
                         )));
@@ -264,6 +414,10 @@ impl Player {
         };
 
         if terminal {
+            debug!(
+                title = %title,
+                "waiting for the Android player to finish before returning control to the TUI",
+            );
             wait_for_android_player().await?;
         }
         Ok(Some(code))
@@ -404,6 +558,13 @@ fn mpv_options(stream: &StreamLink, title: &str, referer: &str) -> Vec<String> {
     }
     if let Some(track) = stream.subtitles.iter().find(|track| track.default) {
         args.push(format!("--slang={}", track.label));
+    }
+    // Add cache settings for HLS relay streams
+    if stream.hls && crate::anikoto::requires_hls_relay(stream) {
+        args.push("--cache=yes".into());
+        args.push("--cache-secs=120".into());
+        args.push("--demuxer-max-bytes=512MiB".into());
+        args.push("--demuxer-max-back-bytes=256MiB".into());
     }
     args
 }


### PR DESCRIPTION
feat(logging): enhance debug logging for player and stream resolution

fix(player): improve player launch error handling and validation

fix(hls): add cache settings for HLS relay streams

## Summary

Describe the problem and the resulting behavior. Keep unrelated changes in separate pull requests.

## Related issue

Closes #

## Testing

List the commands and platforms used to verify the change.

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

## Checklist

- [ ] The change is focused and its commit history is understandable.
- [ ] User-facing flags, environment variables, or behavior are documented.
- [ ] New scraper behavior has deterministic fixtures or mock-server coverage.
- [ ] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [ ] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [ ] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

