### PR TITLE
fix: restore live Anikoto.cz search and provider flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with Anikoto providers and a reusable provider/playback library"

--- a/commit-message.txt
+++ b/commit-message.txt
@@ -1,1 +1,8 @@
-feat: show download size, speed, percentage, and ETA progress
+fix: restore live Anikoto.cz search and provider flow
+
+- restore Anikoto.cz filter-page search as the canonical source
+- fix stale provider/default behavior and improve live result parsing
+- deduplicate parsed results and normalize watch URLs/slug handling
+- support sort variants and generated filter URLs for real catalog results
+- polish CLI help styling without breaking non-TTY/script output
+- verify the patch release with the full test suite

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,42 +1,34 @@
-# ani-cli-rs 0.9.4
- 
-This release fixes video player launching issues.
- 
+# ani-cli-rs 0.10.2
+
+This patch release fixes the search flow and brings the default provider back in line with the live Anikoto.cz catalog used by real results.
+
+## Highlights
+
+- Restored the Anikoto.cz filter page as the canonical search source
+- Fixed stale API assumptions that dropped real matches or returned incomplete results
+- Improved result parsing and deduplication for the live filter page
+- Kept the CLI help output readable and styled for interactive terminals without breaking non-TTY/script output
+- Preserved log file behavior and environment overrides for troubleshooting
+
 ## Fixes
- 
-- Fixed video player launching failures by adding HLS relay cache settings to mpv arguments
-- Added mpv cache parameters (`--cache=yes`, `--cache-secs=120`, `--demuxer-max-bytes=512MiB`, `--demuxer-max-back-bytes=256MiB`) for relayed streams
-- Enhanced player executable validation to provide better error messages when players are not found
-- Improved process detachment behavior to match koto-cli's nohup behavior
-- Fixed URL argument ordering to ensure the stream URL is passed as the last argument to mpv
-- These changes resolve playback issues with Anikoto provider's HLS streams and relay mechanism
 
-## Debug logging improvements
+- Fixed provider default drift and made the current catalog behavior consistent again
+- Corrected parsing of `#list-items` results to ignore unrelated markup outside the real result list
+- Deduplicated duplicate show entries and normalized slug handling for watch URLs
+- Improved search sort handling and generated filter URLs for supported sort variants
+- Updated CLI styling to use auto color detection so scripts and tests keep plain output while terminals still get the warm rust/orange theme
 
-The application includes comprehensive debug logging through the `tracing` crate to help with troubleshooting and issue reporting:
+## Notes
 
-- Player launch logging with executable details, process IDs, and command arguments
-- Stream resolution logging with URLs, HLS status, and provider information
-- HLS relay logging with bind addresses, upstream hosts, and resource registration
-- Network request logging for provider API calls and stream fetching
-- Error context logging with structured metadata for better debugging
-
-Enable debug logging with:
-```console
-RUST_LOG=ani_cli_rs=debug,ani_cli=debug ani-cli-rs "anime title"
-```
-
-For full stream resolution and relay tracing:
-```console
-RUST_LOG=ani_cli_rs=trace,ani_cli=trace ani-cli-rs "anime title"
-```
+- The live Anikoto.cz search flow is now the default path for real catalog data
+- This is a patch release; no breaking CLI or API changes are expected for existing users
 
 ## Upgrade
- 
+
 Existing installations can update with:
- 
+
 ```console
 ani-cli-rs update
 ```
- 
-**Full changelog:** [0.9.3...0.9.4](https://github.com/vorlie/ani-cli-rs/compare/0.9.3...0.9.4)
+
+**Full changelog:** [0.10.1...0.10.2](https://github.com/vorlie/ani-cli-rs/compare/0.10.1...0.10.2)

--- a/src/anikoto_cz.rs
+++ b/src/anikoto_cz.rs
@@ -13,8 +13,8 @@ use serde_json::Value;
 use url::Url;
 
 use crate::{
-    AniError, CatalogProvider, RequestHeaders, Result, SearchOptions, SearchResult, StreamLink,
-    SubtitleTrack, TranslationType,
+    AniError, CatalogProvider, RequestHeaders, Result, SearchOptions, SearchResult, SearchSort,
+    StreamLink, SubtitleTrack, TranslationType,
     models::{sort_episodes, sort_streams},
 };
 
@@ -149,25 +149,63 @@ impl AnikotoCzClient {
         &self,
         query: &str,
         _mode: TranslationType,
-        _options: SearchOptions,
+        options: SearchOptions,
     ) -> Result<Vec<SearchResult>> {
         let query = query.trim();
         if query.is_empty() {
             return Err(AniError::InputEmptyQuery);
         }
-        let mut url = Url::parse(&format!("{}/ajax/anime/search", self.inner.base))?;
-        url.query_pairs_mut().append_pair("keyword", query);
-        let payload = self
-            .get_json(url.as_str(), &self.inner.base, true, None)
-            .await?;
-        let result = provider_result(&payload, "search")?;
-        let html = result
-            .as_str()
-            .or_else(|| result.get("html").and_then(Value::as_str))
-            .ok_or_else(|| {
-                AniError::Provider("Anikoto.cz search response contained no markup".into())
-            })?;
-        parse_search(&self.inner.base, html)
+
+        let mut request_urls = filter_search_urls_for_base(&self.inner.base, query, options.sort);
+        let mut ajax_url = Url::parse(&format!("{}/ajax/anime/search", self.inner.base))?;
+        ajax_url.query_pairs_mut().append_pair("keyword", query);
+        request_urls.push(ajax_url.to_string());
+
+        for request_url in request_urls {
+            let html = if request_url.contains("/filter") {
+                match self
+                    .get_text(
+                        &request_url,
+                        &self.inner.base,
+                        false,
+                        None,
+                        MAX_RESPONSE_BYTES,
+                    )
+                    .await
+                {
+                    Ok(html) => html,
+                    Err(_) => continue,
+                }
+            } else {
+                let payload = match self
+                    .get_json(&request_url, &self.inner.base, true, None)
+                    .await
+                {
+                    Ok(payload) => payload,
+                    Err(_) => continue,
+                };
+                let result = match provider_result(&payload, "search") {
+                    Ok(result) => result,
+                    Err(_) => continue,
+                };
+                match result
+                    .as_str()
+                    .or_else(|| result.get("html").and_then(Value::as_str))
+                {
+                    Some(html) => html.into(),
+                    None => continue,
+                }
+            };
+
+            let results = parse_search(&self.inner.base, &html)?;
+            if !results.is_empty() {
+                return Ok(results);
+            }
+        }
+
+        Err(AniError::Provider(format!(
+            "Anikoto.cz returned no search results for {query:?}"
+        )))
     }
 
     pub async fn episodes(&self, show_id: &str, mode: TranslationType) -> Result<Vec<String>> {
@@ -529,18 +567,74 @@ fn decode_id(value: &str) -> Result<AnikotoCzId> {
     Ok(decoded)
 }
 
+fn filter_search_urls_for_base(
+    base: &str,
+    query: &str,
+    preferred_sort: Option<SearchSort>,
+) -> Vec<String> {
+    let base = Url::parse(base).unwrap_or_else(|_| Url::parse("https://anikoto.cz").unwrap());
+    let defaults = [
+        SearchSort::LatestUpdated,
+        SearchSort::LatestAdded,
+        SearchSort::Score,
+        SearchSort::NameAz,
+        SearchSort::ReleaseDate,
+        SearchSort::MostViewed,
+        SearchSort::NumberOfEpisodes,
+    ];
+
+    let mut urls = Vec::new();
+    let mut seen = HashSet::new();
+    let candidates = std::iter::once(None)
+        .chain(std::iter::once(preferred_sort))
+        .chain(defaults.into_iter().map(Some));
+
+    for sort in candidates {
+        let sort_value = sort.map(|value| value.to_string());
+        if !seen.insert(sort_value.clone()) {
+            continue;
+        }
+
+        let mut url = base.join("/filter").unwrap();
+        {
+            let mut query_pairs = url.query_pairs_mut();
+            query_pairs.clear();
+            query_pairs.append_pair("keyword", query);
+            query_pairs.append_pair("type", "");
+            query_pairs.append_pair("ep_min", "");
+            query_pairs.append_pair("ep_max", "");
+            if let Some(sort) = sort_value.as_deref() {
+                query_pairs.append_pair("sort", sort);
+            }
+        }
+        urls.push(url.to_string());
+    }
+    urls
+}
+
+#[cfg(test)]
+fn filter_search_urls(query: &str) -> Vec<String> {
+    filter_search_urls_for_base("https://anikoto.cz", query, None)
+}
+
 fn parse_search(base: &str, html: &str) -> Result<Vec<SearchResult>> {
     let document = Html::parse_fragment(html);
-    let item = Selector::parse("a.item")
-        .map_err(|_| AniError::Provider("invalid search selector".into()))?;
+    let list = Selector::parse("#list-items .item")
+        .map_err(|_| AniError::Provider("invalid result list selector".into()))?;
     let title_selector = Selector::parse(".name, .d-title")
         .map_err(|_| AniError::Provider("invalid title selector".into()))?;
     let base = Url::parse(base)?;
     let expected_host = base.host_str().unwrap_or_default();
     let mut seen = HashSet::new();
     let mut results = Vec::new();
-    for element in document.select(&item) {
-        let Some(href) = element.value().attr("href") else {
+    let anchor = Selector::parse("a[href]")
+        .map_err(|_| AniError::Provider("invalid anchor selector".into()))?;
+    for element in document.select(&list) {
+        let Some(href) = element
+            .select(&anchor)
+            .next()
+            .and_then(|anchor| anchor.value().attr("href"))
+        else {
             continue;
         };
         let Ok(url) = base.join(href) else {
@@ -553,6 +647,7 @@ fn parse_search(base: &str, html: &str) -> Result<Vec<SearchResult>> {
             .path()
             .trim_end_matches('/')
             .strip_prefix("/watch/")
+            .and_then(|slug| slug.split('/').next())
             .filter(|slug| validate_slug(slug).is_ok())
         else {
             continue;
@@ -1009,13 +1104,46 @@ mod tests {
     #[test]
     fn parses_search_and_deduplicates_slugs() {
         let html = r#"
-            <a class="item" href="/watch/black-torch-1d364"><div class="name">Black Torch</div></a>
-            <a class="item" href="/watch/black-torch-1d364"><span class="d-title">Duplicate</span></a>
+            <div id="list-items" class="ani items">
+              <div class="item"><a href="/watch/black-torch-1d364"><div class="name">Black Torch</div></a></div>
+              <div class="item"><a href="/watch/black-torch-1d364"><span class="d-title">Duplicate</span></a></div>
+            </div>
         "#;
         let values = parse_search("https://anikoto.cz", html).unwrap();
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].name, "Black Torch");
         assert_eq!(values[0].provider, CatalogProvider::Anikoto2);
+    }
+
+    #[test]
+    fn ignores_unrelated_items_outside_the_filter_result_list() {
+        let html = r#"
+            <div class="top-rated">
+              <a class="item" href="/watch/dorohedoro-season-2-bqfe6"><span class="name">Dorohedoro Season 2</span></a>
+            </div>
+            <div id="list-items" class="ani items">
+              <div class="item"><a href="/watch/one-piece-episode-of-luffy-hand-island-adventure-br7lf/ep-1"><span class="d-title">One Piece: Episode of Luffy - Hand Island Adventure</span></a></div>
+            </div>
+        "#;
+        let values = parse_search("https://anikoto.cz", html).unwrap();
+        assert_eq!(values.len(), 1);
+        assert_eq!(
+            values[0].name,
+            "One Piece: Episode of Luffy - Hand Island Adventure"
+        );
+    }
+
+    #[test]
+    fn builds_supported_filter_sort_urls() {
+        let urls = filter_search_urls("one piece");
+        assert_eq!(urls.len(), 8);
+        assert!(urls[0].contains("/filter?keyword=one+piece"));
+        assert!(urls.iter().any(|url| url.contains("sort=latest-updated")));
+        assert!(urls.iter().any(|url| url.contains("sort=name-az")));
+        assert!(
+            urls.iter()
+                .any(|url| url.contains("sort=number_of_episodes"))
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use history::{HistoryEntry, HistoryStore};
 pub use hls_relay::{HlsRelay, relay_stream, relay_stream_without_hls_subtitles};
 pub use i18n::{I18n, Locale};
 pub use models::{
-    CatalogProvider, RequestHeaders, SearchOptions, SearchResult, StreamLink, SubtitleTrack,
-    TranslationType, choose_quality, expand_episode_selection,
+    CatalogProvider, RequestHeaders, SearchOptions, SearchResult, SearchSort, StreamLink,
+    SubtitleTrack, TranslationType, choose_quality, expand_episode_selection,
 };
 pub use player::{Player, PlayerKind, PlayerOptions};

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,90 @@
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    path::PathBuf,
+};
+
+use tracing_subscriber::{
+    EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+fn log_file_path() -> PathBuf {
+    if let Ok(path) = std::env::var("ANI_CLI_LOG_PATH") {
+        return PathBuf::from(path);
+    }
+
+    std::env::current_dir()
+        .unwrap_or_else(|_| std::env::temp_dir())
+        .join("ani-cli-rs.log")
+}
+
+pub fn init() {
+    let filter = EnvFilter::from_default_env();
+    let log_path = log_file_path();
+
+    if let Some(parent) = log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(true)
+        .open(&log_path);
+
+    match file {
+        Ok(mut file) => {
+            let _ = file.write_all(b"\n=== ani-cli-rs log started ===\n");
+            let _ = file.flush();
+
+            tracing_subscriber::registry()
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_target(false)
+                        .compact()
+                        .with_writer(std::io::stderr)
+                        .with_ansi(true)
+                        .with_filter(filter.clone()),
+                )
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_target(false)
+                        .compact()
+                        .with_writer(file)
+                        .with_ansi(false)
+                        .with_filter(filter),
+                )
+                .init();
+        }
+        Err(error) => {
+            eprintln!("Failed to open log file {}: {error}", log_path.display());
+            tracing_subscriber::fmt()
+                .with_target(false)
+                .compact()
+                .with_env_filter(filter)
+                .init();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, path::PathBuf};
+
+    use super::log_file_path;
+
+    #[test]
+    fn log_file_path_respects_env_override() {
+        let override_path = PathBuf::from("/tmp/ani-cli-rs-custom.log");
+        unsafe {
+            env::set_var("ANI_CLI_LOG_PATH", &override_path);
+        }
+
+        let resolved = log_file_path();
+
+        unsafe {
+            env::remove_var("ANI_CLI_LOG_PATH");
+        }
+        assert_eq!(resolved, override_path);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,21 +3,69 @@ use std::{io::IsTerminal, path::PathBuf, str::FromStr};
 use ani_lib::{
     AniError, AnikotoClient, AnikotoCzClient, CatalogProvider, DownloadOptions, HistoryEntry,
     HistoryStore, I18n, Player, PlayerKind, PlayerOptions, Result, SearchOptions, SearchResult,
-    StreamLink, TranslationType, choose_quality, download_stream, expand_episode_selection,
-    provider_from_show_id,
+    SearchSort, StreamLink, TranslationType, choose_quality, download_stream,
+    expand_episode_selection, provider_from_show_id,
 };
 #[cfg(debug_assertions)]
 use ani_lib::{RequestHeaders, SubtitleTrack};
-use clap::{Args, Parser, Subcommand};
+use clap::{
+    Args, ColorChoice, Parser, Subcommand,
+    builder::Styles,
+    builder::styling::{AnsiColor, Color, Style},
+};
 use dialoguer::{FuzzySelect, Input, MultiSelect, Select, theme::ColorfulTheme};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 mod updater;
+mod log;
 
 const LONG_ABOUT: &str = "A cross-platform Rust port of ani-cli for browsing, resolving, playing, and downloading anime from Anikoto providers.\n\nThe interactive workflow searches the selected subbed or dubbed catalog, lists available episodes, resolves current provider links, selects the requested quality, and opens an external player. Anikoto API/MegaPlay is the default; select the independent Anikoto.cz catalog with --provider anikoto2 or ANI_CLI_RS_PROVIDER=anikoto2. Watch history uses the Bash ani-cli tab-separated format, so an existing history directory can be reused.\n\nThe scraper and KotoCDN compatibility relay are implemented entirely in Rust; Python, curl, sed, OpenSSL, Botan, and fzf are not required. Playback uses IINA on macOS, an Android media player from Termux, and mpv on other desktops by default, with optional VLC and Syncplay integrations. Downloads prefer aria2c for parallel transfers when available, with yt-dlp, FFmpeg, and the built-in resumable downloader as fallbacks.";
 
-const AFTER_HELP: &str = "KEYBOARD NAVIGATION:\n  Arrow keys / Tab       Navigate menus\n  j / k                  Move down / up in action menus\n  h / l                  Change pages in action menus\n  Space / Enter          Select or toggle an item\n  Type                    Filter fuzzy anime/episode menus\n  Escape                 Go back immediately from a fuzzy menu\n  q / Escape             Leave an ordinary action menu\n\nEXAMPLES:\n  ani-cli-rs frieren\n  ani-cli-rs --provider anikoto2 \"black torch\"\n  ani-cli-rs --allow-adult \"search query\"\n  ani-cli-rs --dub -q 720p \"cowboy bebop\"\n  ani-cli-rs -S 1 -e 2-4 \"one piece\"\n  ani-cli-rs --continue\n  ani-cli-rs --download -e 1 \"anime title\"\n  ani-cli-rs search --allow-adult --json \"search query\"\n  ani-cli-rs links --json SHOW_ID 1 --quality 1080p\n\nTERMUX:\n  Install an Android video player; do not use the terminal VLC package.\n  --vlc requests Android VLC when explicit intents work. A compatibility fallback\n  uses Android's media handler instead. Keep Termux open for relayed HLS playback.\n\nENVIRONMENT:\n  ANI_CLI_MODE, ANI_CLI_PLAYER, ANI_CLI_DOWNLOAD_DIR, ANI_CLI_QUALITY,\n  ANI_CLI_HIST_DIR, ANI_CLI_ALLOW_ADULT, ANI_CLI_MULTI_SELECTION,\n  ANI_CLI_NO_DETACH, ANI_CLI_EXIT_AFTER_PLAY, ANI_CLI_RS_PROVIDER\n\nDEBUG LOGGING:\n  RUST_LOG=ani_cli_rs=debug,ani_cli=debug    verbose launch diagnostics\n  RUST_LOG=ani_cli_rs=trace,ani_cli=trace    full stream resolution + relay tracing\n  RUST_LOG=warn                              only warnings and errors (default off)\n\nOfficial prebuilt releases are provided for Windows and Linux. Tested macOS and Termux builds are compiled from source.";
+const AFTER_HELP: &str = concat!(
+    "\u{1b}[38;5;208mKEYBOARD NAVIGATION:\u{1b}[0m\n",
+    "  \u{1b}[38;5;214mArrow keys / Tab\u{1b}[0m       Navigate menus\n",
+    "  \u{1b}[38;5;214mj / k\u{1b}[0m                  Move down / up in action menus\n",
+    "  \u{1b}[38;5;214mh / l\u{1b}[0m                  Change pages in action menus\n",
+    "  \u{1b}[38;5;214mSpace / Enter\u{1b}[0m          Select or toggle an item\n",
+    "  \u{1b}[38;5;214mType\u{1b}[0m                    Filter fuzzy anime/episode menus\n",
+    "  \u{1b}[38;5;214mEscape\u{1b}[0m                 Go back immediately from a fuzzy menu\n",
+    "  \u{1b}[38;5;214mq / Escape\u{1b}[0m             Leave an ordinary action menu\n\n",
+    "\u{1b}[38;5;208mEXAMPLES:\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs frieren\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs --provider anikoto2 \"black torch\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs --allow-adult \"search query\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs --dub -q 720p \"cowboy bebop\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs -S 1 -e 2-4 \"one piece\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs --continue\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs --download -e 1 \"anime title\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs search --allow-adult --json \"search query\"\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mani-cli-rs links --json SHOW_ID 1 --quality 1080p\u{1b}[0m\n\n",
+    "\u{1b}[38;5;208mTERMUX:\u{1b}[0m\n",
+    "  \u{1b}[38;5;214mInstall an Android video player; do not use the terminal VLC package.\u{1b}[0m\n",
+    "  \u{1b}[38;5;214m--vlc requests Android VLC when explicit intents work. A compatibility fallback\u{1b}[0m\n",
+    "  \u{1b}[38;5;214muses Android's media handler instead. Keep Termux open for relayed HLS playback.\u{1b}[0m\n\n",
+    "\u{1b}[38;5;208mENVIRONMENT:\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mANI_CLI_MODE, ANI_CLI_PLAYER, ANI_CLI_DOWNLOAD_DIR, ANI_CLI_QUALITY,\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mANI_CLI_HIST_DIR, ANI_CLI_ALLOW_ADULT, ANI_CLI_MULTI_SELECTION,\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mANI_CLI_NO_DETACH, ANI_CLI_EXIT_AFTER_PLAY, ANI_CLI_RS_PROVIDER\u{1b}[0m\n\n",
+    "\u{1b}[38;5;208mDEBUG LOGGING:\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mRUST_LOG=ani_cli_rs=debug,ani_cli=debug\u{1b}[0m    \u{1b}[38;5;214mverbose launch diagnostics\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mRUST_LOG=ani_cli_rs=trace,ani_cli=trace\u{1b}[0m    \u{1b}[38;5;214mfull stream resolution + relay tracing\u{1b}[0m\n",
+    "  \u{1b}[38;5;203mRUST_LOG=warn\u{1b}[0m                              \u{1b}[38;5;214monly warnings and errors (default off)\u{1b}[0m\n\n",
+    "\u{1b}[38;5;214mOfficial prebuilt releases are provided for Windows and Linux. Tested macOS and Termux builds are compiled from source.\u{1b}[0m"
+);
+
+fn cli_styles() -> Styles {
+    Styles::styled()
+        .header(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::Yellow))))
+        .usage(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::BrightYellow))))
+        .literal(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::BrightRed))))
+        .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red))))
+        .valid(Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightYellow))))
+        .invalid(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::Red))))
+        .error(Style::new().bold().fg_color(Some(Color::Ansi(AnsiColor::Red))))
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -25,7 +73,9 @@ const AFTER_HELP: &str = "KEYBOARD NAVIGATION:\n  Arrow keys / Tab       Navigat
     version,
     about = "Browse, play, and download anime from Anikoto providers",
     long_about = LONG_ABOUT,
-    after_help = AFTER_HELP
+    after_help = AFTER_HELP,
+    color = ColorChoice::Auto,
+    styles = cli_styles()
 )]
 struct Cli {
     #[command(subcommand)]
@@ -66,6 +116,9 @@ struct Cli {
     /// Include titles marked as adult in catalog search results.
     #[arg(short = 'a', long, env = "ANI_CLI_ALLOW_ADULT")]
     allow_adult: bool,
+    /// Preferred Anikoto.cz sort order for the filter page.
+    #[arg(long, env = "ANI_CLI_SEARCH_SORT", value_parser = SearchSort::from_str)]
+    sort: Option<SearchSort>,
     /// Keep the player attached and wait for it to exit.
     #[arg(long, env = "ANI_CLI_NO_DETACH")]
     no_detach: bool,
@@ -130,6 +183,9 @@ struct SearchArgs {
     /// Include titles marked as adult in search results.
     #[arg(short = 'a', long, env = "ANI_CLI_ALLOW_ADULT")]
     allow_adult: bool,
+    /// Preferred Anikoto.cz sort order for the filter page.
+    #[arg(long, value_parser = SearchSort::from_str)]
+    sort: Option<SearchSort>,
     /// Print structured JSON instead of tab-separated text.
     #[arg(long)]
     json: bool,
@@ -192,11 +248,7 @@ struct ActionArgs {
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_target(false)
-        .compact()
-        .init();
+    log::init();
     if let Err(error) = run(Cli::parse()).await {
         let i18n = I18n::default();
         eprintln!("\x1b[31merror:\x1b[0m {}", i18n.error(&error));
@@ -205,6 +257,10 @@ async fn main() {
 }
 
 async fn run(cli: Cli) -> Result<()> {
+    let effective_provider = cli.provider.or_else(|| {
+        cli.sort.map(|_| CatalogProvider::Anikoto2)
+    });
+
     if cli.update {
         return updater::run(false).await;
     }
@@ -228,7 +284,7 @@ async fn run(cli: Cli) -> Result<()> {
 
     let clients = ProviderClients::new(cli.demo_mode())?;
     if let Some(command) = cli.command {
-        return run_command(&clients, cli.provider, command).await;
+        return run_command(&clients, effective_provider, command).await;
     }
     let history = HistoryStore::platform_default()?;
     if cli.delete {
@@ -286,11 +342,12 @@ async fn run(cli: Cli) -> Result<()> {
                 };
                 let results = clients
                     .search_with_options(
-                        cli.provider.unwrap_or_default(),
+                        effective_provider.unwrap_or_default(),
                         &query,
                         mode,
                         SearchOptions {
                             allow_adult: cli.allow_adult,
+                            sort: cli.sort,
                         },
                     )
                     .await?;
@@ -632,6 +689,7 @@ async fn run_command(
                     TranslationType::from_str(&args.mode)?,
                     SearchOptions {
                         allow_adult: args.allow_adult,
+                        sort: args.sort,
                     },
                 )
                 .await?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -65,10 +65,64 @@ impl FromStr for TranslationType {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+pub enum SearchSort {
+    #[serde(rename = "latest-updated")]
+    LatestUpdated,
+    #[serde(rename = "latest-added")]
+    LatestAdded,
+    Score,
+    #[serde(rename = "name-az")]
+    NameAz,
+    #[serde(rename = "release-date")]
+    ReleaseDate,
+    #[serde(rename = "most-viewed")]
+    MostViewed,
+    #[serde(rename = "number_of_episodes")]
+    NumberOfEpisodes,
+}
+
+impl fmt::Display for SearchSort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::LatestUpdated => "latest-updated",
+            Self::LatestAdded => "latest-added",
+            Self::Score => "score",
+            Self::NameAz => "name-az",
+            Self::ReleaseDate => "release-date",
+            Self::MostViewed => "most-viewed",
+            Self::NumberOfEpisodes => "number_of_episodes",
+        })
+    }
+}
+
+impl FromStr for SearchSort {
+    type Err = AniError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let normalized = value.trim().to_ascii_lowercase().replace('_', "-");
+        match normalized.as_str() {
+            "latest-updated" => Ok(Self::LatestUpdated),
+            "latest-added" => Ok(Self::LatestAdded),
+            "score" => Ok(Self::Score),
+            "name-az" | "nameaz" => Ok(Self::NameAz),
+            "release-date" | "releasedate" => Ok(Self::ReleaseDate),
+            "most-viewed" | "mostviewed" => Ok(Self::MostViewed),
+            "number-of-episodes" | "numberofepisodes" => Ok(Self::NumberOfEpisodes),
+            _ => Err(AniError::Input(format!(
+                "search sort must be one of: latest-updated, latest-added, score, name-az, release-date, most-viewed, number_of_episodes; got {value}"
+            ))),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SearchOptions {
     /// Include titles marked as adult by the selected catalog.
     pub allow_adult: bool,
+    /// Preferred ordering for provider-specific search filter URLs.
+    #[serde(default)]
+    pub sort: Option<SearchSort>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -229,6 +283,28 @@ mod tests {
             headers: RequestHeaders::default(),
             subtitles: vec![],
         }
+    }
+
+    #[test]
+    fn default_provider_is_anikoto_cz() {
+        assert_eq!(CatalogProvider::default(), CatalogProvider::Anikoto2);
+    }
+
+    #[test]
+    fn parse_search_sort_variants() {
+        assert_eq!(
+            SearchSort::from_str("latest-updated").unwrap(),
+            SearchSort::LatestUpdated
+        );
+        assert_eq!(SearchSort::from_str("score").unwrap(), SearchSort::Score);
+        assert_eq!(
+            SearchSort::from_str("number_of_episodes").unwrap(),
+            SearchSort::NumberOfEpisodes
+        );
+        assert_eq!(
+            SearchSort::from_str("most-viewed").unwrap(),
+            SearchSort::MostViewed
+        );
     }
 
     #[test]


### PR DESCRIPTION
- restore Anikoto.cz filter-page search as the canonical source
- fix stale provider/default behavior and improve live result parsing
- deduplicate parsed results and normalize watch URLs/slug handling
- support sort variants and generated filter URLs for real catalog results
- polish CLI help styling without breaking non-TTY/script output
- verify the patch release with the full test suite

## Summary

Describe the problem and the resulting behavior. Keep unrelated changes in separate pull requests.

## Related issue

Closes #

## Testing

List the commands and platforms used to verify the change.

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

## Checklist

- [ ] The change is focused and its commit history is understandable.
- [ ] User-facing flags, environment variables, or behavior are documented.
- [ ] New scraper behavior has deterministic fixtures or mock-server coverage.
- [ ] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [ ] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [ ] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

