### PR TITLE
fix source_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "ani-cli-rs"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-cli-rs"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Cross-platform Rust port of ani-cli with Anikoto providers and a reusable provider/playback library"

--- a/src/anikoto_cz.rs
+++ b/src/anikoto_cz.rs
@@ -455,7 +455,7 @@ impl AnikotoCzClient {
         data_id: &str,
         mode: TranslationType,
     ) -> Result<Value> {
-        let mut source_url = Url::parse(&format!("{origin}/stream/getSources"))?;
+        let mut source_url = Url::parse(&format!("{origin}/stream/getSourcesNew"))?;
         // VidTube shares episode IDs across languages and defaults to sub.
         source_url
             .query_pairs_mut()
@@ -1115,7 +1115,7 @@ mod tests {
             let embed_url = format!("https://vidtube.site/stream/example/{language}");
             let media_url = format!("https://media.example/{language}.m3u8");
             Mock::given(method("GET"))
-                .and(path("/stream/getSources"))
+                .and(path("/stream/getSourcesNew"))
                 .and(query_param("id", "42"))
                 .and(query_param("type", language))
                 .and(header("Referer", embed_url.as_str()))


### PR DESCRIPTION
## Summary

Changes the `source_url` in `get_native_sources`, getting the non-encrypted master source file.

## Related issue

Closes #

## Testing

List the commands and platforms used to verify the change.

```console
cargo fmt --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test
```

## Checklist

- [x] The change is focused and its commit history is understandable.
- [ ] User-facing flags, environment variables, or behavior are documented.
- [ ] New scraper behavior has deterministic fixtures or mock-server coverage.
- [ ] No credentials, cookies, complete signed media URLs, personal paths, or generated debug dumps are committed.
- [ ] Existing Bash ani-cli compatibility is preserved or an intentional difference is explained.
- [x] I have tested relevant player, downloader, installer, or platform-specific behavior where practical.

